### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Daniel (dmilith) Dettlaff <dmilith@me.com>"]
 description = "CertsD - automated, asynchronous LE certificate issuer."
 keywords = ["acme"]
 categories = ["asynchronous"]
-homepage = "https://github.com/VerKnowSys/certsd-open"
+repository = "https://github.com/VerKnowSys/certsd-open"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.